### PR TITLE
fix: include root workspace scripts in lauf list

### DIFF
--- a/.changeset/include-root-scripts.md
+++ b/.changeset/include-root-scripts.md
@@ -1,0 +1,5 @@
+---
+'laufen': patch
+---
+
+Include root workspace package scripts in `lauf list` output for monorepos

--- a/packages/lauf/src/handlers/list.test.ts
+++ b/packages/lauf/src/handlers/list.test.ts
@@ -44,14 +44,9 @@ vi.mock('../lib/paths.ts', () => ({
   resolveTsx: vi.fn(() => [null, '/lauf-root/node_modules/.bin/tsx']),
 }));
 
-vi.mock('../lib/workspace.ts', () => ({
-  getWorkspaceInfo: vi.fn(() => ({ manager: 'pnpm', root: '/workspace', globs: ['packages/*'] })),
-}));
-
 import { loadAllLaufConfigs, safeLoadLaufConfigWithMeta } from '../lib/config.ts';
 import { discoverScripts } from '../lib/discovery.ts';
 import { resolveTsx } from '../lib/paths.ts';
-import { getWorkspaceInfo } from '../lib/workspace.ts';
 import listHandler from './list.ts';
 
 beforeEach(() => {
@@ -595,8 +590,8 @@ describe('list handler --all flag', () => {
   });
 });
 
-describe('root package filtering', () => {
-  it('filters out scripts from the workspace root package in monorepo mode', async () => {
+describe('root package scripts', () => {
+  it('includes scripts from the workspace root package in monorepo mode', async () => {
     vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
       null,
       {
@@ -622,41 +617,12 @@ describe('root package filtering', () => {
 
     await listHandler({ flags: {} });
 
-    // Only the sub-package script should remain after filtering
-    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('1 script(s)'));
+    // Both root and sub-package scripts should appear
+    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('2 script(s)'));
     expect(process.exit).not.toHaveBeenCalled();
   });
 
-  it('keeps root package scripts in single-package mode', async () => {
-    vi.mocked(getWorkspaceInfo).mockReturnValue({
-      manager: 'single',
-      root: '/workspace',
-      globs: [],
-    });
-    vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
-      null,
-      {
-        config: { scripts: ['scripts/*.ts'], logger: undefined, spinner: true },
-        configFile: 'lauf.config.ts',
-        configDir: '/workspace',
-      },
-    ]);
-    vi.mocked(discoverScripts).mockReturnValue([
-      {
-        name: 'my-pkg/build',
-        path: '/workspace/scripts/build.ts',
-        packageDir: '/workspace',
-        packageName: 'my-pkg',
-      },
-    ]);
-
-    await listHandler({ flags: {} });
-
-    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('1 script(s)'));
-    expect(process.exit).not.toHaveBeenCalled();
-  });
-
-  it('shows no-scripts warning when all scripts belong to root package', async () => {
+  it('displays root-only scripts in monorepo mode', async () => {
     vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
       null,
       {
@@ -676,8 +642,9 @@ describe('root package filtering', () => {
 
     await listHandler({ flags: {} });
 
-    expect(p.log.warn).toHaveBeenCalledWith('No scripts found.');
-    expect(p.note).not.toHaveBeenCalled();
+    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('1 script(s)'));
+    expect(p.log.warn).not.toHaveBeenCalledWith('No scripts found.');
+    expect(process.exit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/lauf/src/handlers/list.ts
+++ b/packages/lauf/src/handlers/list.ts
@@ -16,7 +16,6 @@ import { defineHandler } from '../lib/handler.ts';
 import { LAUF_ROOT, getWorkspaceRoot, resolveTsx } from '../lib/paths.ts';
 import { fail, ok } from '../lib/result.ts';
 import type { DiscoveredScript } from '../lib/types.ts';
-import { getWorkspaceInfo } from '../lib/workspace.ts';
 import { safeParseError } from '../utils/cli.ts';
 import { safeParseJSON } from '../utils/json.ts';
 import { buildScriptTree } from '../utils/tree.ts';
@@ -78,42 +77,22 @@ async function listAllScripts() {
 /**
  * Shared display logic for discovered scripts.
  *
- * Filters out root workspace package scripts in monorepo contexts
- * and renders a directory-tree-style hierarchy grouped by package.
+ * Renders a directory-tree-style hierarchy grouped by package,
+ * including scripts from all packages (root and workspace members).
  */
 async function displayScripts(scripts: readonly DiscoveredScript[]) {
-  const filtered = filterRootPackageScripts(scripts);
-
-  if (filtered.length === 0) {
+  if (scripts.length === 0) {
     p.log.warn('No scripts found.');
     p.log.message(pc.dim('Create one with: lauf create <name>'));
     return ok();
   }
 
-  const descriptions = await loadDescriptions(filtered);
-  const tree = buildScriptTree(filtered, descriptions);
+  const descriptions = await loadDescriptions(scripts);
+  const tree = buildScriptTree(scripts, descriptions);
 
-  p.note(tree, `Found ${filtered.length} script(s)`);
+  p.note(tree, `Found ${scripts.length} script(s)`);
 
   return ok();
-}
-
-/**
- * Filter out scripts belonging to the workspace root package in monorepo contexts.
- *
- * In a monorepo, the root package is the workspace container and should not
- * appear as a separate entry alongside real packages.
- * In single-package mode, all scripts are kept.
- */
-function filterRootPackageScripts(
-  scripts: readonly DiscoveredScript[],
-): readonly DiscoveredScript[] {
-  const { manager, root } = getWorkspaceInfo();
-  if (manager === 'single') {
-    return scripts;
-  }
-  const normalizedRoot = path.resolve(root);
-  return scripts.filter((s) => path.resolve(s.packageDir) !== normalizedRoot);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removed `filterRootPackageScripts` from the `list` handler which was excluding scripts belonging to the workspace root package in monorepo mode
- Root scripts are now displayed alongside workspace member scripts in `lauf list` output
- Updated tests to verify root scripts are included rather than filtered out

## Test plan
- [x] All existing tests pass (22/22)
- [x] `list.ts` maintains 100% line/statement/function coverage
- [x] Typecheck passes
- [x] Lint passes