### PR TITLE
fix: display root workspace as <root> in script listings

### DIFF
--- a/.changeset/root-display-name.md
+++ b/.changeset/root-display-name.md
@@ -1,0 +1,5 @@
+---
+'laufen': patch
+---
+
+Display root workspace package as `<root>` instead of its package.json name in script listings

--- a/packages/lauf/src/lib/paths.test.ts
+++ b/packages/lauf/src/lib/paths.test.ts
@@ -59,7 +59,7 @@ describe('resolveWorkspacePackages', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('{"name": "root-pkg"}');
 
     const packages = resolveWorkspacePackages();
-    const found = packages.find((p) => p.name === 'root-pkg');
+    const found = packages.find((p) => p.name === '<root>');
     expect(found).toBeDefined();
   });
 

--- a/packages/lauf/src/lib/paths.ts
+++ b/packages/lauf/src/lib/paths.ts
@@ -70,7 +70,7 @@ export function resolveWorkspacePackages(): readonly PackageInfo[] {
 
   const rootPkg = readPackageInfo(root);
   if (rootPkg) {
-    return [rootPkg, ...packages];
+    return [{ ...rootPkg, name: '<root>' }, ...packages];
   }
   return packages;
 }


### PR DESCRIPTION
## Summary
- Root workspace package now displays as `<root>` instead of its `package.json` name (e.g. "serenity") in `lauf list` tree output
- Updated corresponding test assertion

## Test plan
- [x] All 440 tests pass
- [x] Lint, typecheck, and format all pass