### PR TITLE
fix: make `args` optional on `ScriptConfig`

### DIFF
--- a/.changeset/make-args-optional.md
+++ b/.changeset/make-args-optional.md
@@ -1,0 +1,6 @@
+---
+'@laufen/engine': minor
+'laufen': minor
+---
+
+Make `args` optional on `ScriptConfig` so scripts without arguments can omit it

--- a/packages/engine/src/executor.test.ts
+++ b/packages/engine/src/executor.test.ts
@@ -55,7 +55,7 @@ const { attemptAsyncCallIndex, mockScriptConfig } = vi.hoisted(() => ({
       | undefined
       | {
           description: string;
-          args: Record<string, unknown>;
+          args?: Record<string, unknown>;
           run: ReturnType<typeof vi.fn>;
         },
   },
@@ -332,9 +332,24 @@ describe('executor', () => {
       await runExecutor();
 
       expect(process.exit).toHaveBeenCalledWith(1);
-      expect(mockLogError).toHaveBeenCalledWith(
-        expect.stringContaining('does not export a valid lauf() config'),
-      );
+      expect(mockLogError).toHaveBeenCalledWith(expect.stringContaining('has invalid args'));
+    });
+  });
+
+  describe('no-args script', () => {
+    it('runs successfully when args is omitted', async () => {
+      const mockRunFn = vi.fn();
+      // oxlint-disable-next-line immutable-data
+      mockScriptConfig.value = {
+        description: 'no args script',
+        run: mockRunFn,
+      };
+      mockPromptForMissingArgs.mockResolvedValue([null, {}]);
+
+      await runExecutor();
+
+      expect(mockRunFn).toHaveBeenCalled();
+      expect(process.exit).not.toHaveBeenCalledWith(1);
     });
   });
 

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -102,16 +102,19 @@ async function execute(): Promise<void> {
 
   const config = mod.default;
 
+  if (!config || typeof config.description !== 'string' || typeof config.run !== 'function') {
+    log.error(
+      `Script "${env.LAUF_SCRIPT_NAME}" does not export a valid lauf() config (requires description, run)`,
+    );
+    process.exit(1);
+  }
+
   if (
-    !config ||
-    typeof config.description !== 'string' ||
-    typeof config.args !== 'object' ||
-    config.args === null ||
-    Array.isArray(config.args) ||
-    typeof config.run !== 'function'
+    config.args !== undefined &&
+    (typeof config.args !== 'object' || config.args === null || Array.isArray(config.args))
   ) {
     log.error(
-      `Script "${env.LAUF_SCRIPT_NAME}" does not export a valid lauf() config (requires description, args, run)`,
+      `Script "${env.LAUF_SCRIPT_NAME}" has invalid args: expected a plain object or undefined`,
     );
     process.exit(1);
   }
@@ -161,21 +164,21 @@ async function execute(): Promise<void> {
   applyEnvToProcess(safeResolvedEnv);
 
   if (env.LAUF_HELP === '1') {
-    const argsMeta = extractArgMeta(config.args);
+    const argsMeta = extractArgMeta(config.args ?? {});
     log.message(formatHelp(env.LAUF_SCRIPT_NAME, config.description, argsMeta));
     process.exit(0);
   }
 
   // Prompt for any missing required args before validation
   const prompts = createPrompts();
-  const [promptError, mergedArgs] = await promptForMissingArgs(config.args, rawArgs, prompts);
+  const [promptError, mergedArgs] = await promptForMissingArgs(config.args ?? {}, rawArgs, prompts);
   if (promptError) {
     cancel('Cancelled');
     process.exit(0);
   }
 
   // Build a Zod object schema from the arg definitions and validate
-  const argSchema = z.object(config.args);
+  const argSchema = z.object(config.args ?? {});
 
   const parseResult = argSchema.safeParse(mergedArgs);
 

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -235,16 +235,14 @@ export interface ScriptContext<T extends ArgDefs> {
  *
  * @typeParam T - The argument definitions record
  */
-export interface ScriptConfig<T extends ArgDefs = ArgDefs> {
+export interface ScriptConfig<T extends ArgDefs = Record<string, never>> {
   /**
    * Human-readable description of what the script does.
    */
   description: string;
 
-  /**
-   * Argument definitions using Zod schemas. Keys become CLI flag names.
-   */
-  args: T;
+  /** Argument definitions using Zod schemas. Keys become CLI flag names. Omit for no-arg scripts. */
+  args?: T;
 
   /**
    * Script-level environment variables.

--- a/packages/laufen/src/lauf.test.ts
+++ b/packages/laufen/src/lauf.test.ts
@@ -39,6 +39,16 @@ describe('lauf', () => {
     const result = lauf(config);
     expect(result).toBe(config);
   });
+
+  it('accepts a config without args', () => {
+    const config = {
+      description: 'no args needed',
+      run: () => {},
+    };
+    const result = lauf(config);
+    expect(result).toBe(config);
+    expect(result.args).toBeUndefined();
+  });
 });
 
 describe('defineConfig', () => {

--- a/packages/laufen/src/lauf.ts
+++ b/packages/laufen/src/lauf.ts
@@ -48,7 +48,9 @@ import type { LaufConfig } from './lib/config.ts';
  * })
  * ```
  */
-export function lauf<T extends ArgDefs>(config: ScriptConfig<T>): ScriptConfig<T> {
+export function lauf<T extends ArgDefs = Record<string, never>>(
+  config: ScriptConfig<T>,
+): ScriptConfig<T> {
   return config;
 }
 


### PR DESCRIPTION
## Summary

- Makes `args` optional on `ScriptConfig` so scripts without arguments can simply omit it instead of writing `args: {}`
- Defaults the generic parameter to `Record<string, never>` so callers can omit the type parameter too
- Updates the executor to default `config.args` to `{}` at all usage sites (validation, help, prompting, schema parsing)

## Test plan

- [x] Added executor test: script with no `args` field runs successfully
- [x] Added `lauf()` test: accepts a config without `args`
- [x] Existing tests for array-args rejection still pass with updated error message
- [x] `pnpm typecheck && pnpm lint && pnpm fmt:check && pnpm build && pnpm test` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Script configurations can now omit the `args` property entirely. This allows scripts without arguments to have simpler, cleaner definitions, reducing unnecessary boilerplate configuration code. You can now define scripts more intuitively when no arguments are needed.

* **Improvements**
  * Enhanced script configuration validation with clearer, more specific error messages for invalid argument definitions, improving the debugging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->