### PR TITLE
feat: add namespaced context API and filesystem helpers

### DIFF
--- a/.changeset/namespaced-context-api.md
+++ b/.changeset/namespaced-context-api.md
@@ -1,0 +1,11 @@
+---
+'@laufen/engine': minor
+'laufen': minor
+---
+
+Add namespaced context API and filesystem helpers
+
+- Add `ctx.dir.*` namespace for paths (root, package, workspace)
+- Add `ctx.fs.*` filesystem helpers (readFile, writeFile, copyFile, mkdir, rm, exists, stat)
+- Deprecate `ctx.root` and `ctx.packageDir` (use `ctx.dir.root` and `ctx.dir.package` instead)
+- Add documentation and examples for creating reusable utility libraries

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -35,7 +35,6 @@
     "**/*.d.ts",
     "**/bundle/**",
     ".claude",
-    "examples",
     "scripts",
     "**/CHANGELOG.md"
   ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,11 +37,13 @@ pnpm lauf run @examples/lauf/fetch-releases -- --repo "vercel/next.js"
 
 ## Scripts
 
-| Script            | Description                                         |
-| ----------------- | --------------------------------------------------- |
-| `docs`            | Generate API docs from a source file using AI       |
-| `clean`           | Clean build artifacts with confirmation for safety   |
-| `fetch-releases`  | Fetch GitHub releases for a repo and save to JSON   |
+| Script           | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `docs`           | Generate API docs from a source file using AI      |
+| `clean`          | Clean build artifacts with confirmation for safety |
+| `fetch-releases` | Fetch GitHub releases for a repo and save to JSON  |
+| `with-utils`     | Example using ctx.dir and ctx.fs helpers           |
+| `using-lib`      | Example using shared utility libraries             |
 
 ## Writing your own
 
@@ -60,7 +62,7 @@ export default lauf({
     ctx.logger.info(`Hello, ${ctx.args.name}!`);
 
     if (ctx.args.verbose) {
-      ctx.logger.info(`Running from ${ctx.packageDir}`);
+      ctx.logger.info(`Running from ${ctx.dir.package}`);
     }
 
     ctx.logger.success('Done!');
@@ -72,4 +74,90 @@ Then run it:
 
 ```bash
 pnpm lauf run @examples/lauf/my-custom-script -- --name "Zac"
+```
+
+## Creating Reusable Utilities
+
+You can create shared utility libraries for your scripts:
+
+### 1. Create a lib directory
+
+```
+examples/
+├── lib/
+│   └── utils.ts
+└── scripts/
+    └── my-script.ts
+```
+
+### 2. Export utilities
+
+```typescript
+// lib/utils.ts
+export const formatDate = (date: Date = new Date()): string => {
+  return date.toISOString().split('T')[0];
+};
+
+export const readJsonFile = async <T>(filePath: string): Promise<T> => {
+  const { readFile } = await import('node:fs/promises');
+  const content = await readFile(filePath, 'utf-8');
+  return JSON.parse(content) as T;
+};
+```
+
+### 3. Import in scripts
+
+```typescript
+// scripts/my-script.ts
+import { lauf } from 'laufen';
+import { formatDate, readJsonFile } from '../lib/utils.js';
+
+export default lauf({
+  description: 'Script using shared utilities',
+  async run(ctx) {
+    const data = await readJsonFile('data.json');
+    ctx.logger.info(`Date: ${formatDate()}`);
+  },
+});
+```
+
+**Note:** Use `.js` extension in imports even for `.ts` files (Node ESM convention).
+
+## Context API
+
+The script context (`ctx`) provides:
+
+### Paths
+
+- `ctx.dir.root` - Workspace root (git repository root)
+- `ctx.dir.package` - Package directory where the script lives
+- `ctx.dir.workspace` - Alias for `ctx.dir.package`
+
+### Filesystem Helpers
+
+All paths are resolved relative to the package directory:
+
+- `ctx.fs.readFile(path, encoding?)` - Read file contents
+- `ctx.fs.writeFile(path, data)` - Write file (creates parent dirs)
+- `ctx.fs.copyFile(src, dest)` - Copy file
+- `ctx.fs.mkdir(path)` - Create directory recursively
+- `ctx.fs.rm(path)` - Remove file or directory recursively
+- `ctx.fs.exists(path)` - Check if path exists
+- `ctx.fs.stat(path)` - Get file stats
+
+Example:
+
+```typescript
+export default lauf({
+  async run(ctx) {
+    // Read package.json from package directory
+    const pkg = await ctx.fs.readFile('package.json', 'utf-8');
+
+    // Write to dist/output.json (creates dist/ if needed)
+    await ctx.fs.writeFile('dist/output.json', pkg);
+
+    // Check if file exists
+    const exists = await ctx.fs.exists('tsconfig.json');
+  },
+});
 ```

--- a/examples/lauf.config.ts
+++ b/examples/lauf.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'laufen';
+
+export default defineConfig({
+  scripts: ['scripts/*.ts'],
+});

--- a/examples/lib/utils.ts
+++ b/examples/lib/utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared utilities for lauf scripts.
+ *
+ * Import from scripts like: `import { formatDate } from '../lib/utils.js'`
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * Format a date as YYYY-MM-DD.
+ */
+export const formatDate = (date: Date = new Date()): string => {
+  return date.toISOString().split('T')[0];
+};
+
+/**
+ * Read and parse a JSON file.
+ */
+export const readJsonFile = async <T>(filePath: string): Promise<T> => {
+  const content = await readFile(filePath, 'utf-8');
+  return JSON.parse(content) as T;
+};
+
+/**
+ * Write data to a JSON file, creating parent directories if needed.
+ */
+export const writeJsonFile = async (filePath: string, data: unknown): Promise<void> => {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+};

--- a/examples/scripts/using-lib.ts
+++ b/examples/scripts/using-lib.ts
@@ -1,0 +1,18 @@
+import { lauf } from 'laufen';
+
+import { formatDate, writeJsonFile } from '../lib/utils.js';
+
+export default lauf({
+  description: 'Example script using shared utilities',
+  async run(ctx) {
+    const data = {
+      name: ctx.name,
+      date: formatDate(),
+      workspace: ctx.dir.root,
+      package: ctx.dir.package,
+    };
+
+    await writeJsonFile('output.json', data);
+    ctx.logger.success('Done! Output written to output.json');
+  },
+});

--- a/examples/scripts/with-utils.ts
+++ b/examples/scripts/with-utils.ts
@@ -1,0 +1,30 @@
+import { lauf, z } from 'laufen';
+
+export default lauf({
+  description: 'Example using ctx.dir and ctx.fs',
+  args: {
+    output: z.string().default('dist/output.json'),
+  },
+  async run(ctx) {
+    // Read from package directory
+    const pkgContent = await ctx.fs.readFile('package.json', 'utf-8');
+    const pkg = JSON.parse(pkgContent as string);
+
+    // Access workspace paths
+    ctx.logger.info(`Workspace root: ${ctx.dir.root}`);
+    ctx.logger.info(`Package directory: ${ctx.dir.package}`);
+    ctx.logger.info(`Script name: ${ctx.name}`);
+
+    // Write output using ctx.fs
+    const output = {
+      name: pkg.name,
+      version: pkg.version,
+      workspace: ctx.dir.root,
+      package: ctx.dir.package,
+    };
+
+    await ctx.fs.writeFile(ctx.args.output, JSON.stringify(output, null, 2));
+
+    ctx.logger.success(`Wrote output to ${ctx.args.output}`);
+  },
+});

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
       run: pnpm lauf run sync-pkg-meta && git add packages/laufen/README.md packages/laufen/LICENSE
     format:
       glob: '*.{ts,tsx,js,jsx,json,md,yaml,yml}'
-      run: pnpm fmt {staged_files} && git add {staged_files}
+      run: pnpm oxfmt --no-error-on-unmatched-pattern {staged_files} && git add {staged_files}
 
 pre-push:
   commands:

--- a/packages/engine/src/context/fs-types.ts
+++ b/packages/engine/src/context/fs-types.ts
@@ -1,0 +1,46 @@
+/**
+ * Filesystem helper utilities scoped to a package directory.
+ *
+ * All path arguments are resolved relative to the package directory.
+ */
+export interface FsHelpers {
+  /**
+   * Read file contents. Paths resolved relative to package directory.
+   */
+  readonly readFile: (filePath: string, encoding?: BufferEncoding) => Promise<string | Buffer>;
+
+  /**
+   * Write file contents. Creates parent directories if needed.
+   */
+  readonly writeFile: (filePath: string, data: string | Buffer) => Promise<void>;
+
+  /**
+   * Copy file from source to destination.
+   */
+  readonly copyFile: (src: string, dest: string) => Promise<void>;
+
+  /**
+   * Create directory recursively.
+   */
+  readonly mkdir: (dirPath: string) => Promise<void>;
+
+  /**
+   * Remove file or directory recursively.
+   */
+  readonly rm: (targetPath: string) => Promise<void>;
+
+  /**
+   * Check if path exists.
+   */
+  readonly exists: (filePath: string) => Promise<boolean>;
+
+  /**
+   * Get file stats.
+   */
+  readonly stat: (filePath: string) => Promise<{
+    readonly isFile: () => boolean;
+    readonly isDirectory: () => boolean;
+    readonly size: number;
+    readonly mtime: Date;
+  }>;
+}

--- a/packages/engine/src/context/fs.ts
+++ b/packages/engine/src/context/fs.ts
@@ -1,0 +1,80 @@
+import { copyFile, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import type { FsHelpers } from './fs-types.ts';
+
+const createReadFile =
+  (resolvePath: (path: string) => string) =>
+  (filePath: string, encoding: BufferEncoding = 'utf-8') => {
+    const resolved = resolvePath(filePath);
+    if (encoding) {
+      return readFile(resolved, encoding);
+    }
+    return readFile(resolved);
+  };
+
+const createWriteFile =
+  (resolvePath: (path: string) => string) => async (filePath: string, data: string | Buffer) => {
+    const resolved = resolvePath(filePath);
+    await mkdir(dirname(resolved), { recursive: true });
+    if (typeof data === 'string') {
+      await writeFile(resolved, data, 'utf-8');
+    } else {
+      await writeFile(resolved, data);
+    }
+  };
+
+const createCopyFile =
+  (resolvePath: (path: string) => string) => async (src: string, dest: string) => {
+    const resolvedSrc = resolvePath(src);
+    const resolvedDest = resolvePath(dest);
+    await copyFile(resolvedSrc, resolvedDest);
+  };
+
+const createMkdir = (resolvePath: (path: string) => string) => async (dirPath: string) => {
+  const resolved = resolvePath(dirPath);
+  await mkdir(resolved, { recursive: true });
+};
+
+const createRm = (resolvePath: (path: string) => string) => async (targetPath: string) => {
+  const resolved = resolvePath(targetPath);
+  await rm(resolved, { recursive: true, force: true });
+};
+
+const createExists = (resolvePath: (path: string) => string) => async (filePath: string) => {
+  const resolved = resolvePath(filePath);
+  const result = await stat(resolved)
+    .then(() => true)
+    .catch(() => false);
+  return result;
+};
+
+const createStat = (resolvePath: (path: string) => string) => async (filePath: string) => {
+  const resolved = resolvePath(filePath);
+  const stats = await stat(resolved);
+  return {
+    isFile: () => stats.isFile(),
+    isDirectory: () => stats.isDirectory(),
+    size: stats.size,
+    mtime: stats.mtime,
+  };
+};
+
+/**
+ * Create filesystem helpers scoped to a package directory.
+ *
+ * All paths are resolved relative to the provided package directory.
+ */
+export function createFsHelpers(packageDir: string): FsHelpers {
+  const resolvePath = (filePath: string) => resolve(packageDir, filePath);
+
+  return {
+    readFile: createReadFile(resolvePath),
+    writeFile: createWriteFile(resolvePath),
+    copyFile: createCopyFile(resolvePath),
+    mkdir: createMkdir(resolvePath),
+    rm: createRm(resolvePath),
+    exists: createExists(resolvePath),
+    stat: createStat(resolvePath),
+  };
+}

--- a/packages/engine/src/context/index.ts
+++ b/packages/engine/src/context/index.ts
@@ -1,4 +1,5 @@
 import type { ArgDefs, DefaultLogger, InferArgs, ScriptContext } from '../types.ts';
+import { createFsHelpers } from './fs.ts';
 import { createLogger } from './logger.ts';
 import { createPrompts } from './prompts.ts';
 import { createNoopSpinner, createSpinner } from './spinner.ts';
@@ -20,15 +21,39 @@ function resolveSpinner(enabled: boolean) {
   return createNoopSpinner();
 }
 
+const warnedDeprecations = new Set<string>();
+
+function warnDeprecation(key: string, replacement: string): void {
+  if (warnedDeprecations.has(key)) {
+    return;
+  }
+  warnedDeprecations.add(key);
+  console.warn(`[lauf] ctx.${key} is deprecated, use ctx.${replacement} instead`);
+}
+
 export function createContext<T extends ArgDefs>(params: CreateContextParams<T>): ScriptContext<T> {
+  const fsHelpers = createFsHelpers(params.packageDir);
+
   return {
     args: params.args,
     env: Object.freeze(params.env),
-    root: params.root,
-    packageDir: params.packageDir,
+    dir: {
+      root: params.root,
+      package: params.packageDir,
+      workspace: params.packageDir,
+    },
+    get root() {
+      warnDeprecation('root', 'dir.root');
+      return params.root;
+    },
+    get packageDir() {
+      warnDeprecation('packageDir', 'dir.package');
+      return params.packageDir;
+    },
     name: params.name,
     logger: params.logger ?? createLogger(),
     spinner: resolveSpinner(params.spinner),
     prompts: createPrompts(),
+    fs: fsHelpers,
   };
 }

--- a/packages/engine/src/context/prompt-types.ts
+++ b/packages/engine/src/context/prompt-types.ts
@@ -1,0 +1,97 @@
+import type { Result } from '../result.ts';
+
+/**
+ * A selectable option for {@link Prompts.select}, {@link Prompts.multiselect},
+ * and other list-based prompts.
+ */
+export interface PromptOption<Value> {
+  readonly value: Value;
+  readonly label: string;
+  readonly hint?: string;
+  readonly disabled?: boolean;
+}
+
+/**
+ * Sentinel indicating the user cancelled a prompt.
+ */
+export interface PromptCancelled {
+  readonly cancelled: true;
+}
+
+/**
+ * Result of an interactive prompt: either the resolved value or a
+ * cancellation sentinel.  Follows the same `[error, value]` convention
+ * as {@link Result}.
+ */
+export type PromptResult<T> = Result<T, PromptCancelled>;
+
+/**
+ * Interactive prompt utilities backed by `@clack/prompts`.
+ *
+ * Each method wraps the corresponding clack prompt and handles
+ * cancellation, returning a {@link PromptResult} tuple instead of
+ * throwing or returning a cancel symbol.
+ */
+export interface Prompts {
+  /**
+   * Prompt the user for text input.
+   */
+  text(opts: {
+    readonly message: string;
+    readonly placeholder?: string;
+    readonly defaultValue?: string;
+    readonly initialValue?: string;
+    readonly validate?: (value: string | undefined) => string | Error | undefined;
+  }): Promise<PromptResult<string>>;
+
+  /**
+   * Prompt the user for a yes/no confirmation.
+   */
+  confirm(opts: {
+    readonly message: string;
+    readonly active?: string;
+    readonly inactive?: string;
+    readonly initialValue?: boolean;
+  }): Promise<PromptResult<boolean>>;
+
+  /**
+   * Prompt the user to select a single value from a list.
+   */
+  select<Value>(opts: {
+    readonly message: string;
+    readonly options: ReadonlyArray<PromptOption<Value>>;
+    readonly initialValue?: Value;
+    readonly maxItems?: number;
+  }): Promise<PromptResult<Value>>;
+
+  /**
+   * Prompt the user to select multiple values from a list.
+   */
+  multiselect<Value>(opts: {
+    readonly message: string;
+    readonly options: ReadonlyArray<PromptOption<Value>>;
+    readonly initialValues?: ReadonlyArray<Value>;
+    readonly maxItems?: number;
+    readonly required?: boolean;
+  }): Promise<PromptResult<ReadonlyArray<Value>>>;
+
+  /**
+   * Prompt the user for a password (masked input).
+   */
+  password(opts: {
+    readonly message: string;
+    readonly mask?: string;
+    readonly validate?: (value: string | undefined) => string | Error | undefined;
+  }): Promise<PromptResult<string>>;
+
+  /**
+   * Prompt the user for a file-system path.
+   */
+  path(opts: {
+    readonly message: string;
+    readonly root?: string;
+    readonly directory?: boolean;
+    readonly initialValue?: string;
+    readonly validate?: (value: string | undefined) => string | Error | undefined;
+  }): Promise<PromptResult<string>>;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -13,6 +13,7 @@ export type {
   ArgDefs,
   EnvContext,
   EnvFn,
+  FsHelpers,
   InferArgs,
   ScriptConfig,
   ScriptContext,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,6 +1,14 @@
 import type { z } from 'zod';
 
-import type { Result } from './result.ts';
+import type { FsHelpers } from './context/fs-types.ts';
+import type {
+  PromptCancelled,
+  PromptOption,
+  PromptResult,
+  Prompts,
+} from './context/prompt-types.ts';
+
+export type { FsHelpers, PromptCancelled, PromptOption, PromptResult, Prompts };
 
 /** Context passed to env resolver functions for dynamic env generation. */
 export interface EnvContext {
@@ -88,102 +96,6 @@ export interface Spinner {
 }
 
 /**
- * A selectable option for {@link Prompts.select}, {@link Prompts.multiselect},
- * and other list-based prompts.
- */
-export interface PromptOption<Value> {
-  readonly value: Value;
-  readonly label: string;
-  readonly hint?: string;
-  readonly disabled?: boolean;
-}
-
-/**
- * Sentinel indicating the user cancelled a prompt.
- */
-export interface PromptCancelled {
-  readonly cancelled: true;
-}
-
-/**
- * Result of an interactive prompt: either the resolved value or a
- * cancellation sentinel.  Follows the same `[error, value]` convention
- * as {@link Result}.
- */
-export type PromptResult<T> = Result<T, PromptCancelled>;
-
-/**
- * Interactive prompt utilities backed by `@clack/prompts`.
- *
- * Each method wraps the corresponding clack prompt and handles
- * cancellation, returning a {@link PromptResult} tuple instead of
- * throwing or returning a cancel symbol.
- */
-export interface Prompts {
-  /**
-   * Prompt the user for text input.
-   */
-  text(opts: {
-    readonly message: string;
-    readonly placeholder?: string;
-    readonly defaultValue?: string;
-    readonly initialValue?: string;
-    readonly validate?: (value: string | undefined) => string | Error | undefined;
-  }): Promise<PromptResult<string>>;
-
-  /**
-   * Prompt the user for a yes/no confirmation.
-   */
-  confirm(opts: {
-    readonly message: string;
-    readonly active?: string;
-    readonly inactive?: string;
-    readonly initialValue?: boolean;
-  }): Promise<PromptResult<boolean>>;
-
-  /**
-   * Prompt the user to select a single value from a list.
-   */
-  select<Value>(opts: {
-    readonly message: string;
-    readonly options: ReadonlyArray<PromptOption<Value>>;
-    readonly initialValue?: Value;
-    readonly maxItems?: number;
-  }): Promise<PromptResult<Value>>;
-
-  /**
-   * Prompt the user to select multiple values from a list.
-   */
-  multiselect<Value>(opts: {
-    readonly message: string;
-    readonly options: ReadonlyArray<PromptOption<Value>>;
-    readonly initialValues?: ReadonlyArray<Value>;
-    readonly maxItems?: number;
-    readonly required?: boolean;
-  }): Promise<PromptResult<ReadonlyArray<Value>>>;
-
-  /**
-   * Prompt the user for a password (masked input).
-   */
-  password(opts: {
-    readonly message: string;
-    readonly mask?: string;
-    readonly validate?: (value: string | undefined) => string | Error | undefined;
-  }): Promise<PromptResult<string>>;
-
-  /**
-   * Prompt the user for a file-system path.
-   */
-  path(opts: {
-    readonly message: string;
-    readonly root?: string;
-    readonly directory?: boolean;
-    readonly initialValue?: string;
-    readonly validate?: (value: string | undefined) => string | Error | undefined;
-  }): Promise<PromptResult<string>>;
-}
-
-/**
  * Context passed to the script's `run` function.
  */
 export interface ScriptContext<T extends ArgDefs> {
@@ -200,12 +112,26 @@ export interface ScriptContext<T extends ArgDefs> {
   readonly env: Readonly<Record<string, string>>;
 
   /**
+   * Directory paths organized by namespace.
+   */
+  readonly dir: {
+    /** Absolute path to the workspace root (git repository root) */
+    readonly root: string;
+    /** Absolute path to the package containing this script */
+    readonly package: string;
+    /** Alias for dir.package */
+    readonly workspace: string;
+  };
+
+  /**
    * Absolute path to the monorepo root.
+   * @deprecated Use `ctx.dir.root` instead
    */
   readonly root: string;
 
   /**
    * Absolute path to the package containing this script.
+   * @deprecated Use `ctx.dir.package` instead
    */
   readonly packageDir: string;
 
@@ -228,6 +154,11 @@ export interface ScriptContext<T extends ArgDefs> {
    * Interactive prompt utilities.
    */
   readonly prompts: Prompts;
+
+  /**
+   * Filesystem helper utilities scoped to the package directory.
+   */
+  readonly fs: FsHelpers;
 }
 
 /**

--- a/packages/laufen/src/lauf.ts
+++ b/packages/laufen/src/lauf.ts
@@ -4,6 +4,7 @@ export type {
   DefaultLogger,
   EnvContext,
   EnvFn,
+  FsHelpers,
   InferArgs,
   Logger,
   PromptCancelled,


### PR DESCRIPTION
## Summary

Adds a namespaced context API and filesystem helpers to improve the developer experience:

- **`ctx.dir.*`** - Namespaced directory paths (`root`, `package`, `workspace`)
- **`ctx.fs.*`** - Filesystem helper methods (readFile, writeFile, copyFile, mkdir, rm, exists, stat)
- **Documentation & Examples** - Added examples and docs for creating reusable utility libraries

## Changes

### Core API

1. **Namespaced Paths** - `packages/engine/src/types.ts`
   - `ctx.dir.root` - Workspace root (git repository root)
   - `ctx.dir.package` - Package directory where script lives
   - `ctx.dir.workspace` - Alias for `ctx.dir.package`
   - Deprecated `ctx.root` and `ctx.packageDir` (with console warnings)

2. **Filesystem Helpers** - `packages/engine/src/context/fs-types.ts`, `packages/engine/src/context/fs.ts`
   - `ctx.fs.readFile(path, encoding?)` - Read file contents
   - `ctx.fs.writeFile(path, data)` - Write file (auto-creates parent dirs)
   - `ctx.fs.copyFile(src, dest)` - Copy files
   - `ctx.fs.mkdir(path)` - Create directories recursively
   - `ctx.fs.rm(path)` - Remove files/directories recursively
   - `ctx.fs.exists(path)` - Check if path exists
   - `ctx.fs.stat(path)` - Get file stats
   - All paths resolved relative to package directory

### Examples & Documentation

- `examples/lib/utils.ts` - Shared utility library example
- `examples/scripts/with-utils.ts` - Demo of `ctx.dir` and `ctx.fs`
- `examples/scripts/using-lib.ts` - Demo of importing shared utilities
- `examples/README.md` - Documentation on creating reusable utilities

## Migration

Deprecated properties remain functional but log warnings:
- `ctx.root` → `ctx.dir.root`
- `ctx.packageDir` → `ctx.dir.package`

Breaking changes planned for v2.0.0.

## Verification

- ✅ Build: `pnpm build` passes
- ✅ Type check (engine): passes
- ✅ Lint: `pnpm lint` passes (0 errors)
- ✅ Functional programming compliance

## Notes

- All code follows strict functional programming style
- Split types into separate files to comply with max-lines lint rule
- Pre-existing jiti typecheck issue in laufen package (unrelated to these changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filesystem utilities (ctx.fs) for reading, writing, copying files, and directory operations.
  * Added directory utilities (ctx.dir) for organizing root, package, and workspace paths.
  * Added interactive prompt types for user input (text, confirm, select, multiselect, password, path).

* **Deprecations**
  * Deprecated ctx.root and ctx.packageDir; migrate to ctx.dir.root and ctx.dir.package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->