### PR TITLE
fix(laufen): group list/run output by workspace, scope root to root-only

### DIFF
--- a/.changeset/fix-list-workspace-grouping.md
+++ b/.changeset/fix-list-workspace-grouping.md
@@ -1,0 +1,5 @@
+---
+'laufen': patch
+---
+
+Fix `lauf list` showing nested workspace scripts under root instead of grouped by workspace. Scripts are now re-attributed to their deepest matching workspace package, so the default view at root only shows root-level scripts and `--all` properly groups by workspace.

--- a/packages/laufen/src/handlers/info.test.ts
+++ b/packages/laufen/src/handlers/info.test.ts
@@ -17,6 +17,7 @@ vi.mock('../lib/config.ts', () => ({
 vi.mock('../lib/discovery.ts', () => ({
   discoverScripts: vi.fn(() => []),
   findScript: vi.fn(),
+  reattributeScripts: vi.fn((scripts: unknown[]) => scripts),
 }));
 
 vi.mock('../lib/paths.ts', () => ({

--- a/packages/laufen/src/handlers/list.test.ts
+++ b/packages/laufen/src/handlers/list.test.ts
@@ -20,6 +20,7 @@ vi.mock('../lib/config.ts', () => ({
 vi.mock('../lib/discovery.ts', () => ({
   ROOT_PACKAGE_NAME: '<root>',
   discoverScripts: vi.fn(),
+  reattributeScripts: vi.fn((scripts: unknown[]) => scripts),
 }));
 
 vi.mock('../lib/paths.ts', () => ({
@@ -72,16 +73,16 @@ describe('list handler', () => {
     ]);
     vi.mocked(discoverScripts).mockReturnValue([
       {
-        name: 'pkg/build',
-        path: '/workspace/packages/pkg/scripts/build.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/build',
+        path: '/workspace/packages/my-pkg/scripts/build.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
       {
-        name: 'pkg/test',
-        path: '/workspace/packages/pkg/scripts/test.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/test',
+        path: '/workspace/packages/my-pkg/scripts/test.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
     ]);
 
@@ -153,10 +154,10 @@ describe('list handler', () => {
   it('calls loadDescriptions with scripts and options', async () => {
     const scripts = [
       {
-        name: 'pkg/build',
-        path: '/workspace/packages/pkg/scripts/build.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/build',
+        path: '/workspace/packages/my-pkg/scripts/build.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
     ];
     vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
@@ -204,21 +205,21 @@ describe('list handler', () => {
     ]);
     vi.mocked(discoverScripts).mockReturnValue([
       {
-        name: 'pkg/build',
-        path: '/workspace/packages/pkg/scripts/build.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/build',
+        path: '/workspace/packages/my-pkg/scripts/build.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
       {
-        name: 'pkg/test',
-        path: '/workspace/packages/pkg/scripts/test.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/test',
+        path: '/workspace/packages/my-pkg/scripts/test.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
     ]);
     vi.mocked(loadDescriptions).mockResolvedValue({
-      '/workspace/packages/pkg/scripts/build.ts': 'Build the project',
-      '/workspace/packages/pkg/scripts/test.ts': 'Run tests',
+      '/workspace/packages/my-pkg/scripts/build.ts': 'Build the project',
+      '/workspace/packages/my-pkg/scripts/test.ts': 'Run tests',
     });
 
     await listHandler({ flags: {} });
@@ -606,7 +607,8 @@ describe('list handler default mode (current package)', () => {
 });
 
 describe('root package scripts', () => {
-  it('includes scripts from the workspace root package in monorepo mode', async () => {
+  it('filters to only root scripts when current package is root', async () => {
+    vi.mocked(resolveCurrentPackage).mockReturnValue({ name: '<root>', dir: '/workspace' });
     vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
       null,
       {
@@ -625,10 +627,10 @@ describe('root package scripts', () => {
     ]);
     vi.mocked(discoverScripts).mockReturnValue([
       {
-        name: 'my-monorepo/root-script',
+        name: 'root-script',
         path: '/workspace/scripts/root-script.ts',
         packageDir: '/workspace',
-        packageName: 'my-monorepo',
+        packageName: '<root>',
       },
       {
         name: 'pkg/build',
@@ -640,12 +642,13 @@ describe('root package scripts', () => {
 
     await listHandler({ flags: {} });
 
-    // Both root and sub-package scripts should appear
-    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('2 script(s)'));
+    // Only root scripts should appear (pkg/build is filtered out)
+    expect(p.note).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('1 script(s)'));
     expect(process.exit).not.toHaveBeenCalled();
   });
 
   it('displays root-only scripts in monorepo mode', async () => {
+    vi.mocked(resolveCurrentPackage).mockReturnValue({ name: '<root>', dir: '/workspace' });
     vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
       null,
       {
@@ -664,10 +667,10 @@ describe('root package scripts', () => {
     ]);
     vi.mocked(discoverScripts).mockReturnValue([
       {
-        name: 'my-monorepo/root-script',
+        name: 'root-script',
         path: '/workspace/scripts/root-script.ts',
         packageDir: '/workspace',
-        packageName: 'my-monorepo',
+        packageName: '<root>',
       },
     ]);
 
@@ -681,8 +684,7 @@ describe('root package scripts', () => {
 
 describe('tree display format', () => {
   it('renders tree connectors for packages and scripts', async () => {
-    vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
-      null,
+    vi.mocked(loadAllLaufConfigs).mockResolvedValue([
       {
         config: {
           scripts: ['scripts/*.ts'],
@@ -718,7 +720,7 @@ describe('tree display format', () => {
       },
     ]);
 
-    await listHandler({ flags: {} });
+    await listHandler({ flags: { all: true } });
 
     const noteCall = vi.mocked(p.note).mock.calls[0];
     const output = noteCall[0] as string;
@@ -747,10 +749,10 @@ describe('tree display format', () => {
     ]);
     vi.mocked(discoverScripts).mockReturnValue([
       {
-        name: 'pkg/build',
-        path: '/workspace/packages/pkg/scripts/build.ts',
-        packageDir: '/workspace/packages/pkg',
-        packageName: 'pkg',
+        name: 'my-pkg/build',
+        path: '/workspace/packages/my-pkg/scripts/build.ts',
+        packageDir: '/workspace/packages/my-pkg',
+        packageName: 'my-pkg',
       },
     ]);
 
@@ -760,7 +762,7 @@ describe('tree display format', () => {
     const output = noteCall[0] as string;
     const lines = output.split('\n');
     // Single package should render as header (like <root>), not nested with └──
-    expect(lines[0]).toContain('pkg');
+    expect(lines[0]).toContain('my-pkg');
     expect(lines[0]).not.toContain('└── ');
     expect(lines[0]).not.toContain('├── ');
     // Script should be a direct child with └── (last item)
@@ -769,8 +771,7 @@ describe('tree display format', () => {
   });
 
   it('renders <root> as top-level heading with scripts and packages nested beneath', async () => {
-    vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
-      null,
+    vi.mocked(loadAllLaufConfigs).mockResolvedValue([
       {
         config: {
           scripts: ['scripts/*.ts'],
@@ -800,7 +801,7 @@ describe('tree display format', () => {
       },
     ]);
 
-    await listHandler({ flags: {} });
+    await listHandler({ flags: { all: true } });
 
     const noteCall = vi.mocked(p.note).mock.calls[0];
     const output = noteCall[0] as string;
@@ -817,8 +818,7 @@ describe('tree display format', () => {
   });
 
   it('renders <root> with only root scripts and no sub-packages', async () => {
-    vi.mocked(safeLoadLaufConfigWithMeta).mockResolvedValue([
-      null,
+    vi.mocked(loadAllLaufConfigs).mockResolvedValue([
       {
         config: {
           scripts: ['scripts/*.ts'],
@@ -848,7 +848,7 @@ describe('tree display format', () => {
       },
     ]);
 
-    await listHandler({ flags: {} });
+    await listHandler({ flags: { all: true } });
 
     const noteCall = vi.mocked(p.note).mock.calls[0];
     const output = noteCall[0] as string;

--- a/packages/laufen/src/handlers/list.ts
+++ b/packages/laufen/src/handlers/list.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 import type { LoadedConfig } from '../lib/config.ts';
 import { loadAllLaufConfigs, safeLoadLaufConfigWithMeta } from '../lib/config.ts';
-import { discoverScripts } from '../lib/discovery.ts';
+import { discoverScripts, reattributeScripts } from '../lib/discovery.ts';
 import { defineHandler } from '../lib/handler.ts';
 import { LAUF_ROOT, getWorkspaceRoot, resolveCurrentPackage } from '../lib/paths.ts';
 import { fail, ok } from '../lib/result.ts';
@@ -51,7 +51,7 @@ async function listFilteredScripts(filterGlob: string) {
   }
 
   const scripts = discoverScripts(loaded.config.scripts, { filterGlobs: [filterGlob] });
-  return displayScripts(scripts);
+  return displayScripts(reattributeScripts(scripts));
 }
 
 /**
@@ -71,8 +71,11 @@ async function listCurrentPackageScripts() {
     });
   }
 
-  const scripts = discoverScripts(loaded.config.scripts, { packageDir: currentPkg.dir });
-  return displayScripts(scripts);
+  const scripts = reattributeScripts(
+    discoverScripts(loaded.config.scripts, { packageDir: currentPkg.dir }),
+  );
+  const currentOnly = scripts.filter((s) => s.packageName === currentPkg.name);
+  return displayScripts(currentOnly);
 }
 
 /**
@@ -88,7 +91,7 @@ async function listAllScripts() {
   // Deduplicate by script path (closest config wins since configs are sorted shallowest-first)
   const unique = uniqBy(allScripts, (s) => s.path);
 
-  return displayScripts(unique);
+  return displayScripts(reattributeScripts(unique));
 }
 
 /**

--- a/packages/laufen/src/handlers/run.test.ts
+++ b/packages/laufen/src/handlers/run.test.ts
@@ -19,6 +19,7 @@ vi.mock('../lib/config.ts', () => ({
 vi.mock('../lib/discovery.ts', () => ({
   discoverScripts: vi.fn(() => []),
   findScript: vi.fn(),
+  reattributeScripts: vi.fn((scripts: unknown[]) => scripts),
 }));
 
 vi.mock('../lib/paths.ts', () => ({

--- a/packages/laufen/src/lib/discovery.ts
+++ b/packages/laufen/src/lib/discovery.ts
@@ -213,6 +213,49 @@ function filterPackagesByScope(
   });
 }
 
+/**
+ * Re-attribute scripts to their deepest matching workspace package.
+ *
+ * Corrects attribution when a parent package's glob patterns reach into
+ * a nested workspace package.
+ */
+export function reattributeScripts(
+  scripts: readonly DiscoveredScript[],
+): readonly DiscoveredScript[] {
+  const packages = resolveWorkspacePackages();
+
+  return scripts.map((script) => {
+    const resolved = path.resolve(script.path);
+    const matching = packages.filter((pkg) => {
+      const pkgDir = path.resolve(pkg.dir);
+      return resolved.startsWith(`${pkgDir}${path.sep}`);
+    });
+
+    if (matching.length === 0) {
+      return script;
+    }
+
+    const deepest = matching.reduce((best, pkg) => {
+      if (pkg.dir.length > best.dir.length) {
+        return pkg;
+      }
+      return best;
+    });
+
+    if (deepest.name === script.packageName) {
+      return script;
+    }
+
+    const stem = stripScriptSuffix(path.basename(script.path, '.ts'));
+    return {
+      name: qualifyScriptName(deepest.name, stem),
+      path: script.path,
+      packageDir: deepest.dir,
+      packageName: deepest.name,
+    };
+  });
+}
+
 function stripScriptSuffix(stem: string): string {
   if (stem.endsWith('.laufen')) {
     return stem.slice(0, -'.laufen'.length);

--- a/packages/laufen/src/utils/resolve-script.ts
+++ b/packages/laufen/src/utils/resolve-script.ts
@@ -1,4 +1,4 @@
-import { discoverScripts, findScript } from '../lib/discovery.ts';
+import { discoverScripts, findScript, reattributeScripts } from '../lib/discovery.ts';
 import { fail, ok } from '../lib/result.ts';
 import type { HandlerResult } from '../lib/result.ts';
 import type { DiscoveredScript } from '../lib/types.ts';
@@ -40,7 +40,9 @@ export function resolveScript(
 
   const packageDir = options && options.packageDir;
   if (packageDir) {
-    return promptForScript(discoverScripts(patterns, { packageDir }));
+    const scripts = reattributeScripts(discoverScripts(patterns, { packageDir }));
+    const scoped = scripts.filter((s) => s.packageDir === packageDir);
+    return promptForScript(scoped);
   }
-  return promptForScript(discoverScripts(patterns));
+  return promptForScript(reattributeScripts(discoverScripts(patterns)));
 }


### PR DESCRIPTION
## Summary

- When a root config's glob patterns reach into nested workspace packages (e.g. `examples/scripts/*.ts`), discovered scripts were attributed to `<root>` instead of their actual workspace
- `lauf list` at root now only shows root-level scripts (not nested workspace scripts)
- `lauf list --all` properly groups scripts by their actual workspace package
- `lauf run` interactive prompt at root only shows root-level scripts
- Added `reattributeScripts()` in discovery.ts that reassigns each script to its deepest matching workspace package based on file path

## Test plan

- [x] `lauf list` from root → only shows `sync-pkg-meta`
- [x] `lauf list --all` from root → shows all 8 scripts grouped by workspace
- [x] `lauf list` from `examples/` → shows only `@examples/lauf` scripts
- [x] Typecheck passes
- [x] Lint passes